### PR TITLE
Added more information when an error occurs

### DIFF
--- a/Api.php
+++ b/Api.php
@@ -125,7 +125,7 @@ class Api
             if ($info['http_code'] >= 200 && $info['http_code'] < 300) {
                 return json_decode($data, true);
             } else {
-                throw new \Exception('HTTP Error', $info['http_code']);
+                throw new \Exception('PHP-API HTTP Error: '.$url, $info['http_code']);
             }
         }
 


### PR DESCRIPTION
When an error occurs the url is not show in the message, so you cannot see which call is failing.
With the new version the url is now visible.